### PR TITLE
Removed copyright from code files

### DIFF
--- a/Arc.StringSanitizer/SanitizerConfig.cs
+++ b/Arc.StringSanitizer/SanitizerConfig.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) 2023, Arnab Roy Chowdhury and Contributors.
-// All rights reserved. Licensed under the MIT License; see LICENSE.txt.
-
-namespace Arc.StringSanitizer;
+﻿namespace Arc.StringSanitizer;
 
 /// <summary>
 /// Config for string sanitisation.

--- a/Arc.StringSanitizer/StringSanitizerExtensions.cs
+++ b/Arc.StringSanitizer/StringSanitizerExtensions.cs
@@ -1,7 +1,4 @@
-﻿// Copyright (c) 2023, Arnab Roy Chowdhury and Contributors.
-// All rights reserved. Licensed under the MIT License; see LICENSE.txt.
-
-using System.Text;
+﻿using System.Text;
 
 namespace Arc.StringSanitizer;
 

--- a/Arc.StringSanitizerTest/SanitizerWithMultipleConfigTest.cs
+++ b/Arc.StringSanitizerTest/SanitizerWithMultipleConfigTest.cs
@@ -1,6 +1,3 @@
-// Copyright (c) 2023, Arnab Roy Chowdhury and Contributors.
-// All rights reserved. Licensed under the MIT License; see LICENSE.txt.
-
 using Arc.StringSanitizer;
 using Xunit;
 

--- a/Arc.StringSanitizerTest/SanitizerWithSingleConfigTest.cs
+++ b/Arc.StringSanitizerTest/SanitizerWithSingleConfigTest.cs
@@ -1,6 +1,3 @@
-// Copyright (c) 2023, Arnab Roy Chowdhury and Contributors.
-// All rights reserved. Licensed under the MIT License; see LICENSE.txt.
-
 using Arc.StringSanitizer;
 using Xunit;
 

--- a/Arc.StringSanitizerTest/UnsanitizerWithMultipleConfigTest.cs
+++ b/Arc.StringSanitizerTest/UnsanitizerWithMultipleConfigTest.cs
@@ -1,6 +1,3 @@
-// Copyright (c) 2023, Arnab Roy Chowdhury and Contributors.
-// All rights reserved. Licensed under the MIT License; see LICENSE.txt.
-
 using Arc.StringSanitizer;
 using Xunit;
 

--- a/Arc.StringSanitizerTest/UnsanitizerWithSingleConfigTest.cs
+++ b/Arc.StringSanitizerTest/UnsanitizerWithSingleConfigTest.cs
@@ -1,6 +1,3 @@
-// Copyright (c) 2023, Arnab Roy Chowdhury and Contributors.
-// All rights reserved. Licensed under the MIT License; see LICENSE.txt.
-
 using Arc.StringSanitizer;
 using Xunit;
 


### PR DESCRIPTION
Removed copyright from code files to reduce the noise. You can find the license information in the 'LICENSE.txt' at the root of the repo.