### PR TITLE
.NET 9 support

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -9,7 +9,7 @@ on:
     types: [ published ]
 
 env:
-  DOTNET_VERSION: 7.0.x
+  DOTNET_VERSION: 9.0.x
   CONFIGURATION: Release
 
 jobs:
@@ -43,6 +43,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/src/Arc.StringSanitizer/Arc.StringSanitizer.csproj
+++ b/src/Arc.StringSanitizer/Arc.StringSanitizer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>11</LangVersion>

--- a/test/Arc.StringSanitizerTest/Arc.StringSanitizerTest.csproj
+++ b/test/Arc.StringSanitizerTest/Arc.StringSanitizerTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
In this PR, I have upgraded the project into `.NET 9` and remove the `.NET 6` and `7` support. The projects which use `.NET 6` and `7`, this is a breaking change for them. They need to upgrade their project into `.NET 9` to be able to use the latest version of this library.

Fixes #26 