### PR TITLE
Use lang version only for netstandard2.0 and netstandard2.1

### DIFF
--- a/src/Arc.StringSanitizer/Arc.StringSanitizer.csproj
+++ b/src/Arc.StringSanitizer/Arc.StringSanitizer.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net9.0</TargetFrameworks>
-    <LangVersion>11</LangVersion>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net9.0</TargetFrameworks>    
     <Authors>Arnab Roy Chowdhury</Authors>
     <Description>This library is to sanitize and unsanitize string</Description>
     <Copyright>Copyright (c) 2023 Arnab Roy Chowdhury</Copyright>
@@ -34,4 +33,8 @@
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
+    <LangVersion>13</LangVersion>
+  </PropertyGroup>
+  
 </Project>


### PR DESCRIPTION
In this PR, I have used lang version only for `netstandard2.0` and `netstandard2.1`. It is not needed for the `.NET 9`.

Fixes #39 