### PR TITLE
Shouldly package for unit test

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
   </ItemGroup>

--- a/test/Arc.StringSanitizerTest/Arc.StringSanitizerTest.csproj
+++ b/test/Arc.StringSanitizerTest/Arc.StringSanitizerTest.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit"/>
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Arc.StringSanitizerTest/GlobalUsings.cs
+++ b/test/Arc.StringSanitizerTest/GlobalUsings.cs
@@ -1,2 +1,3 @@
 ﻿global using Arc.StringSanitizer;
+global using Shouldly;
 global using Xunit;

--- a/test/Arc.StringSanitizerTest/StringSanitizerExtensionsTest.SanitizeMultiple.cs
+++ b/test/Arc.StringSanitizerTest/StringSanitizerExtensionsTest.SanitizeMultiple.cs
@@ -12,7 +12,7 @@ public partial class StringSanitizerExtensionsTest
         var sanitizedString = unsanitizedString.Sanitize(_sanitizerConfigs);
 
         // Assert.
-        Assert.Equal("sample test with [sc]. some more [html space] char", sanitizedString);
+        sanitizedString.ShouldBe("sample test with [sc]. some more [html space] char");
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public partial class StringSanitizerExtensionsTest
         var sanitizedString = unsanitizedString.Sanitize(_sanitizerConfigs);
 
         // Assert.
-        Assert.Equal("sample test with [sc]. some more &nbsp char", sanitizedString);
+        sanitizedString.ShouldBe("sample test with [sc]. some more &nbsp char");
     }
 
     [Fact]
@@ -36,12 +36,12 @@ public partial class StringSanitizerExtensionsTest
 
         // Act.
 #pragma warning disable CS8604 // Possible null reference argument.
-        string func() => unsanitizedString.Sanitize(_sanitizerConfigs);
+        var func = () => unsanitizedString.Sanitize(_sanitizerConfigs);
 #pragma warning restore CS8604 // Possible null reference argument.
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -51,11 +51,11 @@ public partial class StringSanitizerExtensionsTest
         var unsanitizedString = "";
 
         // Act.
-        string func() => unsanitizedString.Sanitize(_sanitizerConfigs);
+        var func = () => unsanitizedString.Sanitize(_sanitizerConfigs);
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -65,11 +65,11 @@ public partial class StringSanitizerExtensionsTest
         var unsanitizedString = " ";
 
         // Act.
-        string func() => unsanitizedString.Sanitize(_sanitizerConfigs);
+        var func = () => unsanitizedString.Sanitize(_sanitizerConfigs);
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -81,12 +81,12 @@ public partial class StringSanitizerExtensionsTest
 
         // Act.
 #pragma warning disable CS8604 // Possible null reference argument.
-        string func() => unsanitizedString.Sanitize(sanitizerConfigs);
+        var func = () => unsanitizedString.Sanitize(sanitizerConfigs);
 #pragma warning restore CS8604 // Possible null reference argument.
 
         // Assert.
-        var ex = Assert.Throws<ArgumentNullException>(func);
-        Assert.Equal("Value cannot be null. (Parameter 'sanitizerConfigs')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentNullException>();
+        ex.Message.ShouldBe("Value cannot be null. (Parameter 'sanitizerConfigs')");
     }
 
     [Fact]
@@ -100,6 +100,6 @@ public partial class StringSanitizerExtensionsTest
         var sanitizedString = unsanitizedString.Sanitize(_sanitizerConfigs);
 
         // Assert.
-        Assert.Equal("sample test with special char. some more &nbsp; char", sanitizedString);
+        sanitizedString.ShouldBe("sample test with special char. some more &nbsp; char");
     }
 }

--- a/test/Arc.StringSanitizerTest/StringSanitizerExtensionsTest.SanitizeSingle.cs
+++ b/test/Arc.StringSanitizerTest/StringSanitizerExtensionsTest.SanitizeSingle.cs
@@ -12,7 +12,7 @@ public partial class StringSanitizerExtensionsTest
         var sanitizedString = unsanitizedString.Sanitize(_sanitizerConfig);
 
         // Assert.
-        Assert.Equal("sample test with [sc]. some more &nbsp; char", sanitizedString);
+        sanitizedString.ShouldBe("sample test with [sc]. some more &nbsp; char");
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public partial class StringSanitizerExtensionsTest
         var sanitizedString = unsanitizedString.Sanitize(_sanitizerConfig);
 
         // Assert.
-        Assert.Equal("sample test with special 1char. some more &nbsp; char", sanitizedString);
+        sanitizedString.ShouldBe("sample test with special 1char. some more &nbsp; char");
     }
 
     [Fact]
@@ -36,12 +36,12 @@ public partial class StringSanitizerExtensionsTest
 
         // Act.
 #pragma warning disable CS8604 // Possible null reference argument.
-        string func() => unsanitizedString.Sanitize(_sanitizerConfig);
+        var func = () => unsanitizedString.Sanitize(_sanitizerConfig);
 #pragma warning restore CS8604 // Possible null reference argument.
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -51,11 +51,11 @@ public partial class StringSanitizerExtensionsTest
         var unsanitizedString = "";
 
         // Act.
-        string func() => unsanitizedString.Sanitize(_sanitizerConfig);
+        var func = () => unsanitizedString.Sanitize(_sanitizerConfig);
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -65,11 +65,11 @@ public partial class StringSanitizerExtensionsTest
         var unsanitizedString = " ";
 
         // Act.
-        string func() => unsanitizedString.Sanitize(_sanitizerConfig);
+        var func = () => unsanitizedString.Sanitize(_sanitizerConfig);
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -81,10 +81,10 @@ public partial class StringSanitizerExtensionsTest
 
         // Act.
 #pragma warning disable CS8604 // Possible null reference argument.
-        string func() => unsanitizedString.Sanitize(sanitizerConfig);
+        var func = () => unsanitizedString.Sanitize(sanitizerConfig);
 #pragma warning restore CS8604 // Possible null reference argument.
 
         // Assert.
-        Assert.Throws<NullReferenceException>(func);
+        func.ShouldThrow<NullReferenceException>();
     }
 }

--- a/test/Arc.StringSanitizerTest/StringSanitizerExtensionsTest.UnsanitizeMultiple.cs
+++ b/test/Arc.StringSanitizerTest/StringSanitizerExtensionsTest.UnsanitizeMultiple.cs
@@ -12,7 +12,7 @@ public partial class StringSanitizerExtensionsTest
         var unsanitizedString = sanitizedString.Unsanitize(_sanitizerConfigs);
 
         // Assert.
-        Assert.Equal("sample test with special char. some more &nbsp; char", unsanitizedString);
+        unsanitizedString.ShouldBe("sample test with special char. some more &nbsp; char");
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public partial class StringSanitizerExtensionsTest
         string unsanitizedString = sanitizedString.Unsanitize(_sanitizerConfigs);
 
         // Assert.
-        Assert.Equal("sample test with [sc1]. some more &nbsp; char", unsanitizedString);
+        unsanitizedString.ShouldBe("sample test with [sc1]. some more &nbsp; char");
     }
 
     [Fact]
@@ -36,12 +36,12 @@ public partial class StringSanitizerExtensionsTest
 
         // Act.
 #pragma warning disable CS8604 // Possible null reference argument.
-        string func() => sanitizedString.Unsanitize(_sanitizerConfigs);
+        var func = () => sanitizedString.Unsanitize(_sanitizerConfigs);
 #pragma warning restore CS8604 // Possible null reference argument.
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -51,11 +51,11 @@ public partial class StringSanitizerExtensionsTest
         var sanitizedString = "";
 
         // Act.
-        string func() => sanitizedString.Unsanitize(_sanitizerConfigs);
+        var func = () => sanitizedString.Unsanitize(_sanitizerConfigs);
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -65,11 +65,11 @@ public partial class StringSanitizerExtensionsTest
         var sanitizedString = " ";
 
         // Act.
-        string func() => sanitizedString.Unsanitize(_sanitizerConfigs);
+        var func = () => sanitizedString.Unsanitize(_sanitizerConfigs);
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -81,11 +81,11 @@ public partial class StringSanitizerExtensionsTest
 
         // Act.
 #pragma warning disable CS8604 // Possible null reference argument.
-        string func() => sanitizedString.Unsanitize(sanitizerConfigs);
+        var func = () => sanitizedString.Unsanitize(sanitizerConfigs);
 #pragma warning restore CS8604 // Possible null reference argument.
 
         // Assert.
-        Assert.Throws<ArgumentNullException>(func);
+        func.ShouldThrow<ArgumentNullException>();
     }
 
     [Fact]
@@ -99,6 +99,6 @@ public partial class StringSanitizerExtensionsTest
         var unsanitizedString = sanitizedString.Unsanitize(_sanitizerConfigs);
 
         // Assert.
-        Assert.Equal("sample test with [sc]. some more [html space] char", unsanitizedString);
+        unsanitizedString.ShouldBe("sample test with [sc]. some more [html space] char");
     }
 }

--- a/test/Arc.StringSanitizerTest/StringSanitizerExtensionsTest.UnsanitizeSingle.cs
+++ b/test/Arc.StringSanitizerTest/StringSanitizerExtensionsTest.UnsanitizeSingle.cs
@@ -12,7 +12,7 @@ public partial class StringSanitizerExtensionsTest
         var unsanitizedString = sanitizedString.Unsanitize(_sanitizerConfig);
 
         // Assert.
-        Assert.Equal("sample test with special char. some more [html space] char", unsanitizedString);
+        unsanitizedString.ShouldBe("sample test with special char. some more [html space] char");
     }
 
     [Fact]
@@ -25,7 +25,7 @@ public partial class StringSanitizerExtensionsTest
         var unsanitizedString = sanitizedString.Unsanitize(_sanitizerConfig);
 
         // Assert.
-        Assert.Equal("sample test with [sc1]. some more [html space] char", unsanitizedString);
+        unsanitizedString.ShouldBe("sample test with [sc1]. some more [html space] char");
     }
 
     [Fact]
@@ -36,12 +36,12 @@ public partial class StringSanitizerExtensionsTest
 
         // Act.
 #pragma warning disable CS8604 // Possible null reference argument.
-        string func() => sanitizedString.Unsanitize(_sanitizerConfig);
+        var func = () => sanitizedString.Unsanitize(_sanitizerConfig);
 #pragma warning restore CS8604 // Possible null reference argument.
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -51,11 +51,11 @@ public partial class StringSanitizerExtensionsTest
         var sanitizedString = "";
 
         // Act.
-        string func() => sanitizedString.Unsanitize(_sanitizerConfig);
+        var func = () => sanitizedString.Unsanitize(_sanitizerConfig);
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -65,11 +65,11 @@ public partial class StringSanitizerExtensionsTest
         var sanitizedString = " ";
 
         // Act.
-        string func() => sanitizedString.Unsanitize(_sanitizerConfig);
+        var func = () => sanitizedString.Unsanitize(_sanitizerConfig);
 
         // Assert.
-        var ex = Assert.Throws<ArgumentException>(func);
-        Assert.Equal("'input' cannot be null or empty. (Parameter 'input')", ex.Message);
+        var ex = func.ShouldThrow<ArgumentException>();
+        ex.Message.ShouldBe("'input' cannot be null or empty. (Parameter 'input')");
     }
 
     [Fact]
@@ -81,10 +81,10 @@ public partial class StringSanitizerExtensionsTest
 
         // Act.
 #pragma warning disable CS8604 // Possible null reference argument.
-        string func() => sanitizedString.Unsanitize(sanitizerConfig);
+        var func = () => sanitizedString.Unsanitize(sanitizerConfig);
 #pragma warning restore CS8604 // Possible null reference argument.
 
         // Assert.
-        Assert.Throws<NullReferenceException>(func);
+        func.ShouldThrow<NullReferenceException>();
     }
 }


### PR DESCRIPTION
In this PR, I have replaced `Assert` with `shouldly` in the unit test project. The code becomes more readable for this change.

Fixes #44